### PR TITLE
The image and stat reveal are now wrapped in a .challenge-card__img-w…

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1350,14 +1350,24 @@
   background: rgba(255,203,5,0.06);
 }
 
-.challenge-card__img {
+.challenge-card__img-wrap {
+  position: relative;
   width: clamp(160px, 20vw, 240px);
   height: clamp(160px, 20vw, 240px);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.challenge-card__img {
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   pointer-events: none;
   transition: filter 0.3s;
   filter: drop-shadow(0 12px 24px rgba(0,0,0,0.45));
-  flex-shrink: 0;
+  display: block;
 }
 
 .challenge-card--idle:hover .challenge-card__img {
@@ -1381,14 +1391,21 @@
 
 /* Stat reveal after guess */
 .challenge-card__stat-reveal {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: rgba(255,255,255,0.06);
+  background: rgba(13,13,20,0.82);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255,255,255,0.12);
   border-radius: 10px;
-  padding: 0.35rem 0.9rem;
-  animation: fadeIn 0.3s ease;
+  padding: 0.3rem 0.85rem;
+  animation: fadeIn 0.25s ease;
   pointer-events: none;
+  white-space: nowrap;
 }
 
 .challenge-card__stat-reveal--winner {
@@ -1611,7 +1628,7 @@
     gap: 0.5rem;
     align-items: center;
   }
-  .challenge-card__img {
+  .challenge-card__img-wrap {
     width: clamp(120px, 35vw, 180px);
     height: clamp(120px, 35vw, 180px);
     flex-shrink: 0;

--- a/src/Challenge.js
+++ b/src/Challenge.js
@@ -233,20 +233,21 @@ class Challenge extends React.Component {
                   disabled={phase !== 'playing'}
                 >
                   <div className="challenge-card__glow" />
-                  <img
-                    src={mon.imgLink}
-                    alt={mon.name}
-                    className={`challenge-card__img${side === 'A' ? ' challenge-card__img--flipped' : ''}`}
-                  />
+                  <div className="challenge-card__img-wrap">
+                    <img
+                      src={mon.imgLink}
+                      alt={mon.name}
+                      className={`challenge-card__img${side === 'A' ? ' challenge-card__img--flipped' : ''}`}
+                    />
+                    {/* Stat overlay sits on top of the artwork */}
+                    {(phase === 'correct' || phase === 'wrong') && (
+                      <div className={`challenge-card__stat-reveal${cardState === 'win' || cardState === 'reveal' ? ' challenge-card__stat-reveal--winner' : ''}`}>
+                        <span className="challenge-card__stat-label">{stat.label}</span>
+                        <span className="challenge-card__stat-val">{val}</span>
+                      </div>
+                    )}
+                  </div>
                   <p className="challenge-card__name">{mon.name}</p>
-
-                  {/* Reveal stat value after guess */}
-                  {(phase === 'correct' || phase === 'wrong') && (
-                    <div className={`challenge-card__stat-reveal${cardState === 'win' || cardState === 'reveal' ? ' challenge-card__stat-reveal--winner' : ''}`}>
-                      <span className="challenge-card__stat-label">{stat.label}</span>
-                      <span className="challenge-card__stat-val">{val}</span>
-                    </div>
-                  )}
 
                   {cardState === 'win' && <span className="challenge-card__badge challenge-card__badge--win">✓</span>}
                   {cardState === 'lose' && <span className="challenge-card__badge challenge-card__badge--lose">✗</span>}


### PR DESCRIPTION
…rap div with position: relative. The stat reveal is position: absolute; bottom: 6px; left: 50%; transform: translateX(-50%) so it floats centered at the bottom of the artwork rather than pushing below it. It has a semi-transparent dark background with backdrop-filter: blur so the number stays readable over any Pokémon artwork.